### PR TITLE
made this include actually resolve

### DIFF
--- a/src/python.cc
+++ b/src/python.cc
@@ -1,6 +1,6 @@
 #include <boost/python.hpp>
 #include <iostream>
-#include <boost/eigen_numpy.h>
+#include "eigen_numpy.h"
 
 BOOST_PYTHON_MODULE(boost_numpy_eigen)
 {


### PR DESCRIPTION
Including `<boost/eigen_numpy.h>` only works if the library is already installed, which is a bit of a chicken and egg problem. Changing it to the relative include `"eigen_numpy.h"` makes it work even on a fresh install.
