### PR TITLE
Fixed CMakeLists.txt file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,13 +5,19 @@ project(BoostNumpyEigen)
 # module search path.
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
-find_package(PythonInterp REQUIRED)
-execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
-  "from distutils.sysconfig import get_python_lib;\
-  print(get_python_lib(plat_specific=True, prefix=''))"
-  OUTPUT_VARIABLE PYTHON_SITE_PACKAGES
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-)
+if (NOT DEFINED MODULE_INSTALL_PREFIX)
+  find_package(PythonInterp REQUIRED)
+  execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
+    "from distutils.sysconfig import get_python_lib;\
+    print(get_python_lib(plat_specific=True, prefix=''))"
+    OUTPUT_VARIABLE MODULE_INSTALL_PREFIX
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+endif ()
+
+set(MODULE_INSTALL_PREFIX "${MODULE_INSTALL_PREFIX}" CACHE STRING
+  "Output directory for Python modules.")
+message(STATUS "Installing Python module to: ${MODULE_INSTALL_PREFIX}")
 
 # Find required python packages.
 find_package(PythonLibs REQUIRED)
@@ -45,5 +51,5 @@ set_target_properties(boost_numpy_eigen PROPERTIES
 )
 
 install(TARGETS boost_numpy_eigen
-  LIBRARY DESTINATION "${PYTHON_SITE_PACKAGES}"
+  LIBRARY DESTINATION "${MODULE_INSTALL_PREFIX}"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,7 @@ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 if (NOT DEFINED MODULE_INSTALL_PREFIX)
   find_package(PythonInterp REQUIRED)
   execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
-    "from distutils.sysconfig import get_python_lib;\
-    print(get_python_lib(plat_specific=True, prefix=''))"
+    "from distutils.sysconfig import get_python_lib;print(get_python_lib(plat_specific=True, prefix=''))"
     OUTPUT_VARIABLE MODULE_INSTALL_PREFIX
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )


### PR DESCRIPTION
- Added `MODULE_INSTALL_PREFIX` to put the module into a custom directory. This is necessary if you are building multiple Python modules a `ExternalProject`s and need to install them all in the same directory so relative `import`s work.
- Removed `\` newline continuation, which is apparently only supported in CMake 3 (!?!) :cry: 
