### PR TITLE
Support Python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,15 @@ python:
 install:
   - sudo apt-get -qq update
   - sudo apt-get install -y libboost-python-dev python-numpy python3-numpy libpython-dev libpython3-dev python-sphinx
+  - cd ..
+  - git clone https://github.com/personalrobotics/Boost.NumPy.git
+  - cd Boost.NumPy
+  - mkdir build
+  - cd build
+  - cmake -DBOOST_NUMPY_PYTHON_VERSION=$TRAVIS_PYTHON_VERSION ..
+  - make -j4
+  - sudo make install
+  - cd ../../Boost.NumPy_Eigen
 
 script:
   - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: python
+
+sudo: required
+
+dist: trusty
+
+python:
+  - "2.7"
+  - "3.4"
+
+install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y libboost-python-dev python-numpy python3-numpy libpython-dev libpython3-dev python-sphinx
+
+script:
+  - mkdir build
+  - cd build
+  - cmake .. -DBOOST_NUMPY_EIGEN_PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
+  - make -j4
+  - sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
 
 install:
   - sudo apt-get -qq update
-  - sudo apt-get install -y libboost-python-dev python-numpy python3-numpy libpython-dev libpython3-dev python-sphinx
+  - sudo apt-get install -y libeigen3-dev libboost-python-dev python-numpy python3-numpy libpython-dev libpython3-dev
   - cd ..
   - git clone https://github.com/personalrobotics/Boost.NumPy.git
   - cd Boost.NumPy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,24 +5,34 @@ project(BoostNumpyEigen)
 # module search path.
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
-if (NOT DEFINED MODULE_INSTALL_PREFIX)
-  find_package(PythonInterp REQUIRED)
-  execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
-    "from distutils.sysconfig import get_python_lib;print(get_python_lib(plat_specific=True, prefix=''))"
-    OUTPUT_VARIABLE MODULE_INSTALL_PREFIX
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
-endif ()
+if(NOT BOOST_NUMPY_EIGEN_PYTHON_VERSION)
+  set(BOOST_NUMPY_EIGEN_PYTHON_VERSION 3.4 CACHE STRING "Choose the target Python version (e.g., 3.4, 2.7)" FORCE)
+endif()
+
+find_package(PythonInterp ${BOOST_NUMPY_EIGEN_PYTHON_VERSION} REQUIRED)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
+  "from distutils.sysconfig import get_python_lib;\
+  print(get_python_lib(plat_specific=True, prefix=''))"
+  OUTPUT_VARIABLE PYTHON_SITE_PACKAGES
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
 
 set(MODULE_INSTALL_PREFIX "${MODULE_INSTALL_PREFIX}" CACHE STRING
   "Output directory for Python modules.")
 message(STATUS "Installing Python module to: ${MODULE_INSTALL_PREFIX}")
 
 # Find required python packages.
-find_package(PythonLibs REQUIRED)
-find_package(Boost COMPONENTS python REQUIRED)
+find_package(PythonLibs ${BOOST_NUMPY_EIGEN_PYTHON_VERSION} REQUIRED)
+if(${PYTHON_VERSION_STRING} GREATER 3.0)
+  find_package(Boost COMPONENTS python-py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
+  if (NOT Boost_FOUND)
+    find_package(Boost COMPONENTS python3 REQUIRED)
+  endif()
+else()
+  find_package(Boost COMPONENTS python REQUIRED)
+endif()
 find_package(Eigen3 REQUIRED)
-find_package(NumPy REQUIRED)
+find_package(NumPy ${BOOST_NUMPY_EIGEN_PYTHON_VERSION} REQUIRED)
 find_package(BoostNumpy)
 
 # Global settings for include paths.
@@ -35,20 +45,20 @@ include_directories(
   ${BoostNumpy_INCLUDE_DIR}
 )
 
-add_library(boost_numpy_eigen SHARED
+add_library(BOOST_NUMPY_EIGEN_eigen SHARED
   src/eigen_numpy.cc
   src/python.cc
 )
-target_link_libraries(boost_numpy_eigen
+target_link_libraries(BOOST_NUMPY_EIGEN_eigen
   ${BoostNumPy_LIBRARIES}
   ${Boost_LIBRARIES}
   ${PYTHON_LIBRARIES}
 )
-set_target_properties(boost_numpy_eigen PROPERTIES
+set_target_properties(BOOST_NUMPY_EIGEN_eigen PROPERTIES
   PREFIX ""
   SUFFIX ".so"
 )
 
-install(TARGETS boost_numpy_eigen
-  LIBRARY DESTINATION "${MODULE_INSTALL_PREFIX}"
+install(TARGETS BOOST_NUMPY_EIGEN_eigen
+  LIBRARY DESTINATION "${PYTHON_SITE_PACKAGES}"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,20 +45,20 @@ include_directories(
   ${BoostNumpy_INCLUDE_DIR}
 )
 
-add_library(BOOST_NUMPY_EIGEN_eigen SHARED
+add_library(boost_numpy_eigen SHARED
   src/eigen_numpy.cc
   src/python.cc
 )
-target_link_libraries(BOOST_NUMPY_EIGEN_eigen
+target_link_libraries(boost_numpy_eigen
   ${BoostNumPy_LIBRARIES}
   ${Boost_LIBRARIES}
   ${PYTHON_LIBRARIES}
 )
-set_target_properties(BOOST_NUMPY_EIGEN_eigen PROPERTIES
+set_target_properties(boost_numpy_eigen PROPERTIES
   PREFIX ""
   SUFFIX ".so"
 )
 
-install(TARGETS BOOST_NUMPY_EIGEN_eigen
+install(TARGETS boost_numpy_eigen
   LIBRARY DESTINATION "${PYTHON_SITE_PACKAGES}"
 )

--- a/src/eigen_numpy.cc
+++ b/src/eigen_numpy.cc
@@ -255,9 +255,14 @@ struct EigenTransformFromPython {
 
 static const int X = Eigen::Dynamic;
 
-void SetupEigenConverters() {
+#if PY_MAJOR_VERSION >= 3
+int
+#else
+void
+#endif
+SetupEigenConverters() {
   static bool is_setup = false;
-  if (is_setup) return;
+  if (is_setup) return NUMPY_IMPORT_ARRAY_RETVAL;
   is_setup = true;
 
   import_array();


### PR DESCRIPTION
This PR adds CMake variable `BOOST_NUMPY_EIGEN_PYTHON_VERSION` to correctly support Python2 and Python3 like personalrobotics/dartpy#36.

This PR depends on https://github.com/personalrobotics/Boost.NumPy/pull/3.